### PR TITLE
fix dependencies scope

### DIFF
--- a/galleon-feature-pack/pom.xml
+++ b/galleon-feature-pack/pom.xml
@@ -38,17 +38,14 @@
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>ojdbc8</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>                


### PR DESCRIPTION
Provided scope was wrongly used. This scope is not seen by galleon maven plugin.