### PR TITLE
Fix default sorter, checkers to be no-op

### DIFF
--- a/galleon-feature-pack/src/main/resources/layers/standalone/mariadb-datasource/layer-spec.xml
+++ b/galleon-feature-pack/src/main/resources/layers/standalone/mariadb-datasource/layer-spec.xml
@@ -9,7 +9,7 @@
         <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the important thing is JNDI -->
         <param name="data-source" value="MariaDBDS"/>
         <param name="enabled" value="${org.jboss.eap.datasources.mariadb.enabled,env.MARIADB_ENABLED:true}"/>
-        <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.mariadb.exception-sorter-class-name,env.MARIADB_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter}"/>
+        <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.mariadb.exception-sorter-class-name,env.MARIADB_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter}"/>
         <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="${org.jboss.eap.datasources.mariadb.jndi-name,env.MARIADB_JNDI:java:jboss/datasources/${org.jboss.eap.datasources.mariadb.datasource,env.MARIADB_DATASOURCE:MariaDBDS}}"/>
         <param name="jta" value="${org.jboss.eap.datasources.mariadb.jta,env.MARIADB_JTA:true}"/>
@@ -25,8 +25,8 @@
         <param name="background-validation-millis" value="${org.jboss.eap.datasources.mariadb.background-validation-millis,env.MARIADB_BACKGROUND_VALIDATION_MILLIS:10000}"/>
         <param name="flush-strategy" value="IdleConnections"/>
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
-        <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.mariadb.stale-connection-checker-class-name,env.MARIADB_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLStaleConnectionChecker}" />
-        <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.mariadb.valid-connection-checker-class-name,env.MARIADB_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker}"/>
+        <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.mariadb.stale-connection-checker-class-name,env.MARIADB_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
+        <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.mariadb.valid-connection-checker-class-name,env.MARIADB_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker}"/>
         <param name="transaction-isolation" value="${org.jboss.eap.datasources.mariadb.transaction-isolation,env.MARIADB_TX_ISOLATION:TRANSACTION_READ_COMMITTED}"/>
     </feature>
 </layer-spec>

--- a/galleon-feature-pack/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
+++ b/galleon-feature-pack/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
@@ -8,7 +8,7 @@
         <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the important thing is JNDI -->
         <param name="data-source" value="OracleDS"/>
         <param name="enabled" value="${org.jboss.eap.datasources.oracle.enabled,env.ORACLE_ENABLED:true}"/>
-        <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.oracle.exception-sorter-class-name,env.ORACLE_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter}"/>
+        <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.oracle.exception-sorter-class-name,env.ORACLE_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter}"/>
         <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="${org.jboss.eap.datasources.oracle.jndi-name,env.ORACLE_JNDI:java:jboss/datasources/${org.jboss.eap.datasources.oracle.datasource,env.ORACLE_DATASOURCE:OracleDS}}"/>
         <param name="jta" value="${org.jboss.eap.datasources.oracle.jta,env.ORACLE_JTA:true}"/>
@@ -24,8 +24,8 @@
         <param name="background-validation-millis" value="${org.jboss.eap.datasources.oracle.background-validation-millis,env.ORACLE_BACKGROUND_VALIDATION_MILLIS:10000}"/>
         <param name="flush-strategy" value="IdleConnections"/>
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
-        <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.oracle.stale-connection-checker-class-name,env.ORACLE_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker}" />
-        <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.oracle.valid-connection-checker-class-name,env.ORACLE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker}"/>
+        <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.oracle.stale-connection-checker-class-name,env.ORACLE_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
+        <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.oracle.valid-connection-checker-class-name,env.ORACLE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker}"/>
         <param name="transaction-isolation" value="${org.jboss.eap.datasources.oracle.transaction-isolation,env.ORACLE_TX_ISOLATION:TRANSACTION_READ_COMMITTED}"/>
     </feature>
 </layer-spec>

--- a/galleon-feature-pack/src/main/resources/layers/standalone/postgresql-datasource/layer-spec.xml
+++ b/galleon-feature-pack/src/main/resources/layers/standalone/postgresql-datasource/layer-spec.xml
@@ -9,7 +9,7 @@
         <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the important thing is JNDI -->
         <param name="data-source" value="PostgreSQLDS"/>
         <param name="enabled" value="${org.jboss.eap.datasources.postgresql.enabled, env.POSTGRESQL_ENABLED:true}"/>
-        <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.postgresql.exception-sorter-class-name, env.POSTGRESQL_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter}"/>
+        <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.postgresql.exception-sorter-class-name, env.POSTGRESQL_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter}"/>
         <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="${org.jboss.eap.datasources.postgresql.jndi-name,env.POSTGRESQL_JNDI:java:jboss/datasources/${org.jboss.eap.datasources.postgresql.datasource, env.POSTGRESQL_DATASOURCE:PostgreSQLDS}}"/>
         <param name="jta" value="${org.jboss.eap.datasources.postgresql.jta,env.POSTGRESQL_JTA:true}"/>
@@ -25,8 +25,8 @@
         <param name="background-validation-millis" value="${org.jboss.eap.datasources.postgresql.background-validation-millis,env.POSTGRESQL_BACKGROUND_VALIDATION_MILLIS:10000}"/>
         <param name="flush-strategy" value="IdleConnections"/>
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
-        <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.postgresql.stale-connection-checker-class-name,env.POSTGRESQL_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.postgres.StaleConnectionChecker}" />
-        <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.postgresql.valid-connection-checker-class-name,env.POSTGRESQL_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker}"/>
+        <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.postgresql.stale-connection-checker-class-name,env.POSTGRESQL_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
+        <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.postgresql.valid-connection-checker-class-name,env.POSTGRESQL_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker}"/>
         <param name="transaction-isolation" value="${org.jboss.eap.datasources.postgresql.transaction-isolation,env.POSTGRESQL_TX_ISOLATION:TRANSACTION_READ_COMMITTED}"/>
     </feature>
 </layer-spec>

--- a/testsuite/galleon/src/test/java/org/jboss/eap/datasources/test/SimpleTestCase.java
+++ b/testsuite/galleon/src/test/java/org/jboss/eap/datasources/test/SimpleTestCase.java
@@ -88,36 +88,29 @@ public class SimpleTestCase {
         COMMON_DEFAULT_VALUES.put("statistics-enabled", "false");
         COMMON_DEFAULT_VALUES.put("transaction-isolation", "TRANSACTION_READ_COMMITTED");
         COMMON_DEFAULT_VALUES.put("validate-on-match", "true");
-
+        COMMON_DEFAULT_VALUES.put("stale-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker");
+        COMMON_DEFAULT_VALUES.put("exception-sorter-class-name", "org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter");
+        COMMON_DEFAULT_VALUES.put("valid-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker");
         Map<String, String> mariadb = new HashMap<>();
         SPECIFIC_DEFAULT_VALUES.put(MARIADB_DS, mariadb);
         mariadb.put("connection-url", "jdbc:mariadb://${org.jboss.eap.datasources.mariadb.host,env.MARIADB_SERVICE_HOST,env.MARIADB_HOST}:${org.jboss.eap.datasources.mariadb.port,env.MARIADB_SERVICE_PORT,env.MARIADB_PORT}/${org.jboss.eap.datasources.mariadb.database,env.MARIADB_DATABASE}");
-        mariadb.put("exception-sorter-class-name", "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter");
         mariadb.put("jndi-name", "java:jboss/datasources/MariaDBDS");
         mariadb.put("password", "${org.jboss.eap.datasources.mariadb.password,env.MARIADB_PASSWORD}");
-        mariadb.put("stale-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLStaleConnectionChecker");
         mariadb.put("user-name", "${org.jboss.eap.datasources.mariadb.user-name,env.MARIADB_USER}");
-        mariadb.put("valid-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker");
 
         Map<String, String> oracle = new HashMap<>();
         SPECIFIC_DEFAULT_VALUES.put(ORACLE_DS, oracle);
         oracle.put("connection-url", "${org.jboss.eap.datasources.oracle.connection-url,env.ORACLE_URL}");
-        oracle.put("exception-sorter-class-name", "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter");
         oracle.put("jndi-name", "java:jboss/datasources/OracleDS");
         oracle.put("password", "${org.jboss.eap.datasources.oracle.password,env.ORACLE_PASSWORD}");
-        oracle.put("stale-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker");
         oracle.put("user-name", "${org.jboss.eap.datasources.oracle.user-name,env.ORACLE_USER}");
-        oracle.put("valid-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker");
 
         Map<String, String> postgresql = new HashMap<>();
         SPECIFIC_DEFAULT_VALUES.put(POSTGRESQL_DS, postgresql);
         postgresql.put("connection-url", "jdbc:postgresql://${org.jboss.eap.datasources.postgresql.host,env.POSTGRESQL_SERVICE_HOST,env.POSTGRESQL_HOST}:${org.jboss.eap.datasources.postgresql.port,env.POSTGRESQL_SERVICE_PORT,env.POSTGRESQL_PORT}/${org.jboss.eap.datasources.postgresql.database,env.POSTGRESQL_DATABASE}");
-        postgresql.put("exception-sorter-class-name", "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter");
         postgresql.put("jndi-name", "java:jboss/datasources/PostgreSQLDS");
         postgresql.put("password", "${org.jboss.eap.datasources.postgresql.password,env.POSTGRESQL_PASSWORD}");
-        postgresql.put("stale-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.postgres.StaleConnectionChecker");
         postgresql.put("user-name", "${org.jboss.eap.datasources.postgresql.user-name,env.POSTGRESQL_USER}");
-        postgresql.put("valid-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker");
 
         SYSTEM_PROPERTIES_VALUES.put("org.jboss.eap.datasources." + PLACE_HOLDER + ".enabled", "false");
         SYSTEM_PROPERTIES_VALUES.put("org.jboss.eap.datasources." + PLACE_HOLDER + ".exception-sorter-class-name", "foo");


### PR DESCRIPTION
EAP Documentation https://access.redhat.com/solutions/1433083
states that checker and sorter should be only added if the application is coded to support them. By default we set the default sorters that are no-op ones.
