### PR TITLE
Some datasource updates

### DIFF
--- a/galleon-feature-pack/src/main/resources/layers/standalone/mariadb-datasource/layer-spec.xml
+++ b/galleon-feature-pack/src/main/resources/layers/standalone/mariadb-datasource/layer-spec.xml
@@ -5,12 +5,10 @@
     </dependencies>
     
     <feature spec="subsystem.datasources.data-source">
-        <param name="use-ccm" value="true"/>
         <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the important thing is JNDI -->
         <param name="data-source" value="MariaDBDS"/>
         <param name="enabled" value="${org.jboss.eap.datasources.mariadb.enabled,env.MARIADB_ENABLED:true}"/>
         <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.mariadb.exception-sorter-class-name,env.MARIADB_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter}"/>
-        <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="${org.jboss.eap.datasources.mariadb.jndi-name,env.MARIADB_JNDI:java:jboss/datasources/${org.jboss.eap.datasources.mariadb.datasource,env.MARIADB_DATASOURCE:MariaDBDS}}"/>
         <param name="jta" value="${org.jboss.eap.datasources.mariadb.jta,env.MARIADB_JTA:true}"/>
         <param name="max-pool-size" value="${org.jboss.eap.datasources.mariadb.max-pool-size,env.MARIADB_MAX_POOL_SIZE:20}"/>
@@ -19,11 +17,10 @@
         <param name="driver-name" value="mariadb"/>
         <param name="user-name" value="${org.jboss.eap.datasources.mariadb.user-name,env.MARIADB_USER}"/>
         <param name="password" value="${org.jboss.eap.datasources.mariadb.password,env.MARIADB_PASSWORD}"/>
-        <param name="check-valid-connection-sql" value="SELECT 1"/>
         <param name="validate-on-match" value="${org.jboss.eap.datasources.mariadb.validate-on-match,env.MARIADB_VALIDATE_ON_MATCH:true}"/>
         <param name="background-validation" value="${org.jboss.eap.datasources.mariadb.background-validation,env.MARIADB_BACKGROUND_VALIDATION:false}"/>
         <param name="background-validation-millis" value="${org.jboss.eap.datasources.mariadb.background-validation-millis,env.MARIADB_BACKGROUND_VALIDATION_MILLIS:10000}"/>
-        <param name="flush-strategy" value="IdleConnections"/>
+        <param name="flush-strategy" value="${org.jboss.eap.datasources.mariadb.flush-strategy,env.MARIADB_FLUSH_STRATEGY:FailingConnectionOnly}"/>
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
         <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.mariadb.stale-connection-checker-class-name,env.MARIADB_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
         <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.mariadb.valid-connection-checker-class-name,env.MARIADB_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker}"/>

--- a/galleon-feature-pack/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
+++ b/galleon-feature-pack/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
@@ -4,12 +4,10 @@
         <layer name="oracle-driver"/>
     </dependencies>
     <feature spec="subsystem.datasources.data-source">
-        <param name="use-ccm" value="true"/>
         <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the important thing is JNDI -->
         <param name="data-source" value="OracleDS"/>
         <param name="enabled" value="${org.jboss.eap.datasources.oracle.enabled,env.ORACLE_ENABLED:true}"/>
         <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.oracle.exception-sorter-class-name,env.ORACLE_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter}"/>
-        <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="${org.jboss.eap.datasources.oracle.jndi-name,env.ORACLE_JNDI:java:jboss/datasources/${org.jboss.eap.datasources.oracle.datasource,env.ORACLE_DATASOURCE:OracleDS}}"/>
         <param name="jta" value="${org.jboss.eap.datasources.oracle.jta,env.ORACLE_JTA:true}"/>
         <param name="max-pool-size" value="${org.jboss.eap.datasources.oracle.max-pool-size,env.ORACLE_MAX_POOL_SIZE:20}"/>
@@ -18,11 +16,10 @@
         <param name="driver-name" value="oracle"/>
         <param name="user-name" value="${org.jboss.eap.datasources.oracle.user-name,env.ORACLE_USER}"/>
         <param name="password" value="${org.jboss.eap.datasources.oracle.password,env.ORACLE_PASSWORD}"/>
-        <param name="check-valid-connection-sql" value="SELECT 1"/>
         <param name="validate-on-match" value="${org.jboss.eap.datasources.oracle.validate-on-match,env.ORACLE_VALIDATE_ON_MATCH:true}"/>
         <param name="background-validation" value="${org.jboss.eap.datasources.oracle.background-validation,env.ORACLE_BACKGROUND_VALIDATION:false}"/>
         <param name="background-validation-millis" value="${org.jboss.eap.datasources.oracle.background-validation-millis,env.ORACLE_BACKGROUND_VALIDATION_MILLIS:10000}"/>
-        <param name="flush-strategy" value="IdleConnections"/>
+        <param name="flush-strategy" value="${org.jboss.eap.datasources.oracle.flush-strategy,env.ORACLE_FLUSH_STRATEGY:FailingConnectionOnly}"/>
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
         <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.oracle.stale-connection-checker-class-name,env.ORACLE_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
         <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.oracle.valid-connection-checker-class-name,env.ORACLE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker}"/>

--- a/galleon-feature-pack/src/main/resources/layers/standalone/postgresql-datasource/layer-spec.xml
+++ b/galleon-feature-pack/src/main/resources/layers/standalone/postgresql-datasource/layer-spec.xml
@@ -5,12 +5,10 @@
     </dependencies>
     
     <feature spec="subsystem.datasources.data-source">
-        <param name="use-ccm" value="true"/>
         <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the important thing is JNDI -->
         <param name="data-source" value="PostgreSQLDS"/>
         <param name="enabled" value="${org.jboss.eap.datasources.postgresql.enabled, env.POSTGRESQL_ENABLED:true}"/>
         <param name="exception-sorter-class-name" value="${org.jboss.eap.datasources.postgresql.exception-sorter-class-name, env.POSTGRESQL_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter}"/>
-        <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="${org.jboss.eap.datasources.postgresql.jndi-name,env.POSTGRESQL_JNDI:java:jboss/datasources/${org.jboss.eap.datasources.postgresql.datasource, env.POSTGRESQL_DATASOURCE:PostgreSQLDS}}"/>
         <param name="jta" value="${org.jboss.eap.datasources.postgresql.jta,env.POSTGRESQL_JTA:true}"/>
         <param name="max-pool-size" value="${org.jboss.eap.datasources.postgresql.max-pool-size,env.POSTGRESQL_MAX_POOL_SIZE:20}"/>
@@ -19,11 +17,10 @@
         <param name="driver-name" value="postgresql"/>
         <param name="user-name" value="${org.jboss.eap.datasources.postgresql.user-name,env.POSTGRESQL_USER}"/>
         <param name="password" value="${org.jboss.eap.datasources.postgresql.password,env.POSTGRESQL_PASSWORD}"/>
-        <param name="check-valid-connection-sql" value="SELECT 1"/>
         <param name="validate-on-match" value="${org.jboss.eap.datasources.postgresql.validate-on-match,env.POSTGRESQL_VALIDATE_ON_MATCH:true}"/>
         <param name="background-validation" value="${org.jboss.eap.datasources.postgresql.background-validation,env.POSTGRESQL_BACKGROUND_VALIDATION:false}"/>
         <param name="background-validation-millis" value="${org.jboss.eap.datasources.postgresql.background-validation-millis,env.POSTGRESQL_BACKGROUND_VALIDATION_MILLIS:10000}"/>
-        <param name="flush-strategy" value="IdleConnections"/>
+        <param name="flush-strategy" value="${org.jboss.eap.datasources.postgresql.flush-strategy,env.POSTGRESQL_FLUSH_STRATEGY:FailingConnectionOnly}"/>
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
         <param name="stale-connection-checker-class-name" value="${org.jboss.eap.datasources.postgresql.stale-connection-checker-class-name,env.POSTGRESQL_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
         <param name="valid-connection-checker-class-name" value="${org.jboss.eap.datasources.postgresql.valid-connection-checker-class-name,env.POSTGRESQL_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker}"/>

--- a/testsuite/galleon/pom.xml
+++ b/testsuite/galleon/pom.xml
@@ -129,6 +129,7 @@
                                         <MARIADB_STALE_CONNECTION_CHECKER>envfoostalechecker</MARIADB_STALE_CONNECTION_CHECKER>
                                         <MARIADB_CONNECTION_CHECKER>envfoochecker</MARIADB_CONNECTION_CHECKER>
                                         <MARIADB_TX_ISOLATION>TRANSACTION_READ_UNCOMMITTED</MARIADB_TX_ISOLATION>
+                                        <MARIADB_FLUSH_STRATEGY>IdleConnections</MARIADB_FLUSH_STRATEGY>
                                         
                                         <ORACLE_ENABLED>false</ORACLE_ENABLED>
                                         <ORACLE_EXCEPTION_SORTER>envfoo</ORACLE_EXCEPTION_SORTER>
@@ -145,6 +146,7 @@
                                         <ORACLE_STALE_CONNECTION_CHECKER>envfoostalechecker</ORACLE_STALE_CONNECTION_CHECKER>
                                         <ORACLE_CONNECTION_CHECKER>envfoochecker</ORACLE_CONNECTION_CHECKER>
                                         <ORACLE_TX_ISOLATION>TRANSACTION_READ_UNCOMMITTED</ORACLE_TX_ISOLATION>
+                                        <ORACLE_FLUSH_STRATEGY>IdleConnections</ORACLE_FLUSH_STRATEGY>
                                         
                                         <POSTGRESQL_ENABLED>false</POSTGRESQL_ENABLED>
                                         <POSTGRESQL_EXCEPTION_SORTER>envfoo</POSTGRESQL_EXCEPTION_SORTER>
@@ -161,6 +163,7 @@
                                         <POSTGRESQL_STALE_CONNECTION_CHECKER>envfoostalechecker</POSTGRESQL_STALE_CONNECTION_CHECKER>
                                         <POSTGRESQL_CONNECTION_CHECKER>envfoochecker</POSTGRESQL_CONNECTION_CHECKER>
                                         <POSTGRESQL_TX_ISOLATION>TRANSACTION_READ_UNCOMMITTED</POSTGRESQL_TX_ISOLATION>
+                                        <POSTGRESQL_FLUSH_STRATEGY>IdleConnections</POSTGRESQL_FLUSH_STRATEGY>
                                         
                                     </environmentVariables>
                                 </configuration>

--- a/testsuite/galleon/src/test/java/org/jboss/eap/datasources/test/SimpleTestCase.java
+++ b/testsuite/galleon/src/test/java/org/jboss/eap/datasources/test/SimpleTestCase.java
@@ -91,6 +91,7 @@ public class SimpleTestCase {
         COMMON_DEFAULT_VALUES.put("stale-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker");
         COMMON_DEFAULT_VALUES.put("exception-sorter-class-name", "org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter");
         COMMON_DEFAULT_VALUES.put("valid-connection-checker-class-name", "org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker");
+        COMMON_DEFAULT_VALUES.put("flush-strategy","FailingConnectionOnly");
         Map<String, String> mariadb = new HashMap<>();
         SPECIFIC_DEFAULT_VALUES.put(MARIADB_DS, mariadb);
         mariadb.put("connection-url", "jdbc:mariadb://${org.jboss.eap.datasources.mariadb.host,env.MARIADB_SERVICE_HOST,env.MARIADB_HOST}:${org.jboss.eap.datasources.mariadb.port,env.MARIADB_SERVICE_PORT,env.MARIADB_PORT}/${org.jboss.eap.datasources.mariadb.database,env.MARIADB_DATABASE}");
@@ -129,6 +130,7 @@ public class SimpleTestCase {
         SYSTEM_PROPERTIES_VALUES.put("org.jboss.eap.datasources." + PLACE_HOLDER + ".stale-connection-checker-class-name", "foostale");
         SYSTEM_PROPERTIES_VALUES.put("org.jboss.eap.datasources." + PLACE_HOLDER + ".valid-connection-checker-class-name", "foochecker");
         SYSTEM_PROPERTIES_VALUES.put("org.jboss.eap.datasources." + PLACE_HOLDER + ".transaction-isolation", "TRANSACTION_SERIALIZABLE");
+        SYSTEM_PROPERTIES_VALUES.put("org.jboss.eap.datasources." + PLACE_HOLDER + ".flush-strategy", "IdleConnections");
 
         ENV_VARIABLES_PREFIXES.put(MARIADB_PREFIX, MARIADB_DS);
         ENV_VARIABLES_PREFIXES.put(ORACLE_PREFIX, ORACLE_DS);
@@ -153,6 +155,7 @@ public class SimpleTestCase {
         ENV_TO_ATTRIBUTE.put("_STALE_CONNECTION_CHECKER", "stale-connection-checker-class-name");
         ENV_TO_ATTRIBUTE.put("_CONNECTION_CHECKER", "valid-connection-checker-class-name");
         ENV_TO_ATTRIBUTE.put("_TX_ISOLATION", "transaction-isolation");
+        ENV_TO_ATTRIBUTE.put("_FLUSH_STRATEGY", "flush-strategy");
 
     }
 


### PR DESCRIPTION
* Introduce flush-strategy config point, fixed default value to be FailingConnectionOnly.
* Remove useless attributes set to default values
* Removed check-valid-connection-sql . The way to validate the connection is by using a Connection checker.