### PR TITLE
EAP datasources galleon-pack for 8.0.0.Beta

### DIFF
--- a/galleon-feature-pack/pom.xml
+++ b/galleon-feature-pack/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.eap</groupId>
         <artifactId>eap-datasources-galleon-pack-parent</artifactId>
-        <version>7.4.0.GA-redhat-SNAPSHOT</version>
+        <version>8.0.0.Beta1-redhat-SNAPSHOT</version>
     </parent>
     <artifactId>eap-datasources-galleon-pack</artifactId>
     <packaging>pom</packaging>

--- a/galleon-feature-pack/src/main/resources/modules/com/microsoft/sqlserver/main/module.xml
+++ b/galleon-feature-pack/src/main/resources/modules/com/microsoft/sqlserver/main/module.xml
@@ -4,11 +4,10 @@
         <artifact name="${com.microsoft.sqlserver:mssql-jdbc}"/>
     </resources>
     <dependencies>
-        <module name="javaee.api"/>
+        <module name="wildflyee.api"/>
         <module name="sun.jdk"/>
         <module name="ibm.jdk"/>
         <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
     </dependencies>
 </module>
 

--- a/galleon-feature-pack/src/main/resources/modules/com/oracle/ojdbc/main/module.xml
+++ b/galleon-feature-pack/src/main/resources/modules/com/oracle/ojdbc/main/module.xml
@@ -4,11 +4,10 @@
         <artifact name="${com.oracle.ojdbc:ojdbc8}"/>
     </resources>
     <dependencies>
-        <module name="javaee.api"/>
+        <module name="wildflyee.api"/>
         <module name="sun.jdk"/>
         <module name="ibm.jdk"/>
         <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
     </dependencies>
 </module>
 

--- a/galleon-feature-pack/src/main/resources/modules/org/postgresql/jdbc/main/module.xml
+++ b/galleon-feature-pack/src/main/resources/modules/org/postgresql/jdbc/main/module.xml
@@ -4,11 +4,10 @@
         <artifact name="${org.postgresql:postgresql}"/>
     </resources>
     <dependencies>
-        <module name="javaee.api"/>
+        <module name="wildflyee.api"/>
         <module name="sun.jdk"/>
         <module name="ibm.jdk"/>
         <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
     </dependencies>
 </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.jboss.eap</groupId>
     <artifactId>eap-datasources-galleon-pack-parent</artifactId>
-    <version>7.4.0.GA-redhat-SNAPSHOT</version>
+    <version>8.0.0.Beta1-redhat-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Drivers and datasources for JBoss Entreprise Application Platform parent</name>
     <description>Drivers and datasources for JBoss Entreprise Application Platform parent</description>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <version.junit>4.13.2</version.junit>
         <version.org.codehaus.mojo.properties-maven-plugin>1.0.0</version.org.codehaus.mojo.properties-maven-plugin>
         <version.org.jboss.eap>8.0.0.Beta-redhat-20220907</version.org.jboss.eap>
-        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
+        <version.org.jboss.eap.maven.plugin>1.0.0.Beta3-redhat-00001</version.org.jboss.eap.maven.plugin>
         <version.org.jboss.jboss-dmr>1.5.1.Final-redhat-00001</version.org.jboss.jboss-dmr>
         <version.org.wildfly.core>19.0.0.Beta16-redhat-00002</version.org.wildfly.core>
         <version.org.wildfly.galleon-plugins>6.1.0.Final</version.org.wildfly.galleon-plugins>
@@ -87,9 +87,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.jboss.galleon</groupId>
-                    <artifactId>galleon-maven-plugin</artifactId>
-                    <version>${version.org.jboss.galleon}</version>
+                    <groupId>org.jboss.eap.plugins</groupId>
+                    <artifactId>eap-maven-plugin</artifactId>
+                    <version>${version.org.jboss.eap.maven.plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.wildfly.galleon-plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,16 @@
         </license>
     </licenses>
     <properties>
+        <!-- Require Java 11 -->
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <version.junit>4.13.2</version.junit>
         <version.org.codehaus.mojo.properties-maven-plugin>1.0.0</version.org.codehaus.mojo.properties-maven-plugin>
-        <version.org.jboss.eap>7.4.0.GA-redhat-00003</version.org.jboss.eap>
-        <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
+        <version.org.jboss.eap>8.0.0.Beta-redhat-20220907</version.org.jboss.eap>
+        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
         <version.org.jboss.jboss-dmr>1.5.1.Final-redhat-00001</version.org.jboss.jboss-dmr>
-        <version.org.wildfly.core>15.0.1.Final-redhat-00001</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>5.1.3.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.core>19.0.0.Beta16-redhat-00002</version.org.wildfly.core>
+        <version.org.wildfly.galleon-plugins>6.1.0.Final</version.org.wildfly.galleon-plugins>
         <jbossas.repo.scm.connection>git@github.com:jbossas/eap-datasources-galleon-pack.git</jbossas.repo.scm.connection>
         <jbossas.repo.scm.url>https://github.com/jbossas/eap-datasources-galleon-pack</jbossas.repo.scm.url>   
     </properties>

--- a/testsuite/galleon/pom.xml
+++ b/testsuite/galleon/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.eap</groupId>
         <artifactId>eap-datasources-galleon-pack-testsuite-parent</artifactId>
-        <version>7.4.0.GA-redhat-SNAPSHOT</version>
+        <version>8.0.0.Beta1-redhat-SNAPSHOT</version>
     </parent>
     <artifactId>eap-datasources-galleon-pack-testsuite</artifactId>
     <name>Drivers and datasources for JBoss Entreprise Application Platform galleon testsuite</name>

--- a/testsuite/galleon/pom.xml
+++ b/testsuite/galleon/pom.xml
@@ -104,8 +104,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.jboss.eap.plugins</groupId>
+                <artifactId>eap-maven-plugin</artifactId>
                 <configuration>
                     <feature-packs>
                         <feature-pack>
@@ -119,29 +119,23 @@
                             <version>${project.version}</version>
                         </feature-pack>
                     </feature-packs>
-                    <configurations>
-                        <config>
-                            <model>standalone</model>
-                            <name>standalone.xml</name>
-                            <layers>
-                                <layer>datasources-web-server</layer>
-                                <layer>oracle-datasource</layer>
-                                <layer>postgresql-datasource</layer>
-                                <layer>mssqlserver-datasource</layer>
-                            </layers>
-                        </config>
-                    </configurations>
-                    <install-dir>${project.build.directory}/jboss-eap</install-dir>
-                    <plugin-options>
+                    <layers>
+                        <layer>datasources-web-server</layer>
+                        <layer>oracle-datasource</layer>
+                        <layer>postgresql-datasource</layer>
+                        <layer>mssqlserver-datasource</layer>
+                    </layers>
+                    <galleon-options>
                         <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
-                    </plugin-options>
+                    </galleon-options>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>provision-server</id>
+                        <id>package-server</id>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>package</goal>
                         </goals>
+                        <phase>test-compile</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -68,7 +68,7 @@
                     <failIfNoTests>false</failIfNoTests>
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
-                        <jboss.home>${basedir}/target/jboss-eap</jboss.home>
+                        <jboss.home>${basedir}/target/server</jboss.home>
                         <management.address>${management.address}</management.address>
                         <jboss.args>${jboss.args}</jboss.args>
                     </systemPropertyVariables>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.eap</groupId>
         <artifactId>eap-datasources-galleon-pack-parent</artifactId>
-        <version>7.4.0.GA-redhat-SNAPSHOT</version>
+        <version>8.0.0.Beta1-redhat-SNAPSHOT</version>
     </parent>
     <artifactId>eap-datasources-galleon-pack-testsuite-parent</artifactId>
     <packaging>pom</packaging>


### PR DESCRIPTION
* 8.x version
* Upgraded dependencies
* Cleaned-up JBoss Modules module dependencies
* Use eap-maven-plugin in testsuite.