### PR TITLE
Generate channel when building feature-pack

### DIFF
--- a/galleon-feature-pack/pom.xml
+++ b/galleon-feature-pack/pom.xml
@@ -49,7 +49,8 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <translate-to-fpl>true</translate-to-fpl>
+                            <generate-channel>true</generate-channel>
+                            <add-feature-packs-as-required-channels>false</add-feature-packs-as-required-channels>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Generate the channel without required dependency on EAP feature-pack. This channel streams, would then have to be merged in the EAP channel.
In addition removed a left-over `translate-to-fpl` configuration item that is useless.
