### PR TITLE
Skip deploy of test artifacts

### DIFF
--- a/testsuite/galleon/pom.xml
+++ b/testsuite/galleon/pom.xml
@@ -145,6 +145,13 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -74,6 +74,13 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
Skip maven deploy of artifacts from 'testsuite/pom.xml' and 'testsuite/galleon/pom.xml' There is no much value in deploying those artifacts to registry. Skipping them for now.