### PR TITLE
Fix for JBEAP-29193, For 8.1, uses ojdbc17 artifactId as default  @jfdenise

### DIFF
--- a/doc/oracle/README.md
+++ b/doc/oracle/README.md
@@ -14,7 +14,7 @@ Required configuration
 
 * `ORACLE_DRIVER_VERSION`
 
-  * Description: The version of the `com.oracle.database.jdbc:ojdbc11` Maven artifact.
+  * Description: The version of the `com.oracle.database.jdbc:ojdbc17` Maven artifact.
   * No default value.
   * Required: True
   * System Property: `org.jboss.eap.datasources.oracle.driver.version`
@@ -27,7 +27,7 @@ Configuration that can be provided when provisioning the Galleon feature-pack.
 * `ORACLE_DRIVER_ARTIFACT_ID`
 
   * Description: The artifactId of the driver Maven artifact.
-  * Default value: `ojdbc11`
+  * Default value: `ojdbc17`
   * Required: False
   * System Property: `org.jboss.eap.datasources.oracle.driver.artifactId`
 

--- a/galleon-feature-pack/src/main/resources/resources/wildfly/artifact-versions.properties
+++ b/galleon-feature-pack/src/main/resources/resources/wildfly/artifact-versions.properties
@@ -1,3 +1,3 @@
 com.microsoft.sqlserver:mssql-jdbc=com.microsoft.sqlserver:mssql-jdbc:${org.jboss.eap.datasources.mssqlserver.driver.version,env.MSSQLSERVER_DRIVER_VERSION}::jar
-com.oracle.database.jdbc:ojdbc=${org.jboss.eap.datasources.oracle.driver.groupId,env.ORACLE_DRIVER_GROUP_ID:com.oracle.database.jdbc}:${org.jboss.eap.datasources.oracle.driver.artifactId,env.ORACLE_DRIVER_ARTIFACT_ID:ojdbc11}:${org.jboss.eap.datasources.oracle.driver.version,env.ORACLE_DRIVER_VERSION}::jar
+com.oracle.database.jdbc:ojdbc=${org.jboss.eap.datasources.oracle.driver.groupId,env.ORACLE_DRIVER_GROUP_ID:com.oracle.database.jdbc}:${org.jboss.eap.datasources.oracle.driver.artifactId,env.ORACLE_DRIVER_ARTIFACT_ID:ojdbc17}:${org.jboss.eap.datasources.oracle.driver.version,env.ORACLE_DRIVER_VERSION}::jar
 org.postgresql:postgresql=org.postgresql:postgresql:${org.jboss.eap.datasources.postgresql.driver.version,env.POSTGRESQL_DRIVER_VERSION}::jar

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
         <version.junit>4.13.2</version.junit>
         <version.inject>1</version.inject>
         <version.org.codehaus.mojo.properties-maven-plugin>1.0.0</version.org.codehaus.mojo.properties-maven-plugin>
-        <version.org.jboss.eap>8.0.0.GA-redhat-00011</version.org.jboss.eap>
-        <version.org.jboss.eap.maven.plugin>2.0.0.Final-SNAPSHOT</version.org.jboss.eap.maven.plugin>
+        <version.org.jboss.eap>8.1.0.Beta-redhat-00001</version.org.jboss.eap>
+        <version.org.jboss.eap.maven.plugin>2.0.0.Beta1-redhat-00002</version.org.jboss.eap.maven.plugin>
         <version.org.jboss.jboss-dmr>1.5.1.Final-redhat-00001</version.org.jboss.jboss-dmr>
-        <version.org.wildfly.core>21.0.9.Final-redhat-00001</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>7.3.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.core>27.0.1.Final-redhat-00002</version.org.wildfly.core>
+        <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
         <jbossas.repo.scm.connection>git@github.com:jbossas/eap-datasources-galleon-pack.git</jbossas.repo.scm.connection>
         <jbossas.repo.scm.url>https://github.com/jbossas/eap-datasources-galleon-pack</jbossas.repo.scm.url>   
     </properties>

--- a/testsuite/galleon/pom.xml
+++ b/testsuite/galleon/pom.xml
@@ -64,7 +64,7 @@
         <!-- For dependabot -->
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11</artifactId>
+            <artifactId>ojdbc17</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -34,7 +34,7 @@
         <management.address>${node0}</management.address>
         <node0>127.0.0.1</node0>
         <org.jboss.eap.datasources.mssqlserver.driver.version>9.2.1.jre8</org.jboss.eap.datasources.mssqlserver.driver.version>
-        <org.jboss.eap.datasources.oracle.driver.version>23.2.0.0</org.jboss.eap.datasources.oracle.driver.version>
+        <org.jboss.eap.datasources.oracle.driver.version>23.6.0.24.10</org.jboss.eap.datasources.oracle.driver.version>
         <org.jboss.eap.datasources.postgresql.driver.version>42.2.20</org.jboss.eap.datasources.postgresql.driver.version>
         <testLogToFile>true</testLogToFile>
     </properties>
@@ -43,7 +43,7 @@
         <dependencies>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
-                <artifactId>ojdbc11</artifactId>
+                <artifactId>ojdbc17</artifactId>
                 <version>${org.jboss.eap.datasources.oracle.driver.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-29193